### PR TITLE
Win.DIB coordinates starting from bottom left.

### DIFF
--- a/win/dib_windows.go
+++ b/win/dib_windows.go
@@ -54,7 +54,7 @@ func (p *DIB) At(x, y int) color.Color {
 // PixOffset returns the index of the first element of Pix that corresponds to
 // the pixel at (x, y).
 func (p *DIB) PixOffset(x, y int) int {
-        return (p.Rect.Max.Y-y-p.Rect.Min.Y-1)*p.Stride + (x-p.Rect.Min.X)*4
+        return (y-p.Rect.Min.Y)*p.Stride + (x-p.Rect.Min.X)*4
 }
 
 func (p *DIB) Set(x, y int, c color.Color) {

--- a/win/win_windows.go
+++ b/win/win_windows.go
@@ -176,7 +176,7 @@ func (this *Window) blitImage(hdc w32.HDC) {
 	var bi w32.BITMAPINFO
 	bi.BmiHeader.BiSize = uint(unsafe.Sizeof(bi.BmiHeader))
 	bi.BmiHeader.BiWidth = width
-	bi.BmiHeader.BiHeight = height
+	bi.BmiHeader.BiHeight = -height
 	bi.BmiHeader.BiPlanes = 1
 	bi.BmiHeader.BiBitCount = 32
 	bi.BmiHeader.BiCompression = w32.BI_RGB


### PR DESCRIPTION
Yeah sorry about this. 

Win.DIB starts coordinates from bottom left it seems (w32.BITMAPINFOHEADER can configure that by passing negative BiHeight) and in the new DIB the PixOffset didn't take this into account, resulting in mirrored images when using wde/win. Kinda went under the radar since At(x,y) showed right color in each position.

Changed the PixOffset back to the old one (except 32bit instead of 24bit) and wdetest now shows same image for both xgb and win.
