### PR TITLE
Support for WM_PAINT in windows

### DIFF
--- a/win/events_windows.go
+++ b/win/events_windows.go
@@ -170,7 +170,7 @@ func WndProc(hwnd w32.HWND, msg uint32, wparam, lparam uintptr) uintptr {
 		rc = w32.DefWindowProc(hwnd, msg, wparam, lparam)
 
 	case w32.WM_PAINT:
-		wnd.FlushImage()
+		wnd.Repaint()
 		rc = w32.DefWindowProc(hwnd, msg, wparam, lparam)
 
 	case w32.WM_CLOSE:


### PR DESCRIPTION
WIndows needs the WM_PAINT message to be emitted as an event so the window can be redrawn when exposed by another.
