### PR TITLE
xgb: listen to KeymapNotify events

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Georg Reinke <guelfey@gmail.com>
 Carl O'Dwyer <carlodwyer@googlemail.com>
 Gerard van de Schoot
 Philipp Schröer <hebipp1@googlemail.com>
+sqweek <sqweek@gmail.com>

--- a/xgb/events.go
+++ b/xgb/events.go
@@ -151,6 +151,36 @@ func (w *Window) handleEvents() {
 			delete(downKeys, ke.Key)
 			w.events <- ke
 
+		case xproto.KeymapNotifyEvent:
+			newDownKeys := make(map[string]bool)
+			for i := 0; i < len(e.Keys); i ++ {
+				mask := e.Keys[i]
+				for j := 0; j < 8; j++ {
+					if mask & (1 << uint(j)) != 0 {
+						key := keybind.LookupString(w.xu, 0, xproto.Keycode(8*i + j))
+						newDownKeys[key] = true
+					}
+				}
+			}
+			/* remove keys that are no longer pressed */
+			for key := range downKeys {
+				if _, ok := newDownKeys[key]; !ok {
+					var ke wde.KeyUpEvent
+					ke.Key = key
+					delete(downKeys, key)
+					w.events <- ke
+				}
+			}
+			/* add keys that are newly pressed */
+			for key := range newDownKeys {
+				if _, ok := downKeys[key]; !ok {
+					var ke wde.KeyEvent
+					ke.Key = key
+					downKeys[key] = true
+					w.events <- ke
+				}
+			}
+
 		case xproto.ConfigureNotifyEvent:
 			var re wde.ResizeEvent
 			re.Width = int(e.Width)

--- a/xgb/xgb.go
+++ b/xgb/xgb.go
@@ -47,6 +47,7 @@ func init() {
 
 const AllEventsMask = xproto.EventMaskKeyPress |
 	xproto.EventMaskKeyRelease |
+	xproto.EventMaskKeymapState |
 	xproto.EventMaskButtonPress |
 	xproto.EventMaskButtonRelease |
 	xproto.EventMaskEnterWindow |


### PR DESCRIPTION
To keep downKeys in sync in the face of focus changes, we
must act on KeymapNotify events.
