### PR TITLE
xgb: listen to KeymapNotify events

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Georg Reinke <guelfey@gmail.com>
 Carl O'Dwyer <carlodwyer@googlemail.com>
 Gerard van de Schoot
 Philipp Schröer <hebipp1@googlemail.com>
+sqweek <sqweek@gmail.com>

--- a/xgb/xgb.go
+++ b/xgb/xgb.go
@@ -47,6 +47,7 @@ func init() {
 
 const AllEventsMask = xproto.EventMaskKeyPress |
 	xproto.EventMaskKeyRelease |
+	xproto.EventMaskKeymapState |
 	xproto.EventMaskButtonPress |
 	xproto.EventMaskButtonRelease |
 	xproto.EventMaskEnterWindow |


### PR DESCRIPTION
To keep downKeys in sync in the face of focus changes, we
must act on KeymapNotify events.

KeymapNotify gives us a bitmask indicating which keycodes
are depressed when we regain focus. The first 8 keycodes
are skipped, presumably reserved for the modifiers.

(compared to the previous pull request, this one also sends a proper KeyDownEvent instead of a raw KeyEvent)