### PR TITLE
fix race condition when creating a window failed on Windows

### DIFF
--- a/win/win_windows.go
+++ b/win/win_windows.go
@@ -109,7 +109,9 @@ func NewWindow(width, height int) (w *Window, err error) {
 		var err error
 		w, err = makeTheWindow(width, height)
 		ready <- err
-		w.HandleWndMessages()
+		if err == nil {
+			w.HandleWndMessages()
+		}
 	}(ready)
 
 	err = <-ready

--- a/win/win_windows.go
+++ b/win/win_windows.go
@@ -109,9 +109,10 @@ func NewWindow(width, height int) (w *Window, err error) {
 		var err error
 		w, err = makeTheWindow(width, height)
 		ready <- err
-		if err == nil {
-			w.HandleWndMessages()
+		if err != nil {
+			return
 		}
+		w.HandleWndMessages()
 	}(ready)
 
 	err = <-ready


### PR DESCRIPTION
If `makeTheWindow` returned an error, `w` would be `nil` and `HandleWndMessages` would dereference `w` for `this.hwnd` before the error could be handled.