### PR TITLE
CopyRGBA: support images that don't start at (0,0)

### DIFF
--- a/cocoa/cocoa_darwin.go
+++ b/cocoa/cocoa_darwin.go
@@ -83,7 +83,7 @@ type Image struct {
 }
 
 func (im Image) CopyRGBA(src *image.RGBA, bounds image.Rectangle) {
-	draw.Draw(im.RGBA, bounds, src, image.Point{0, 0}, draw.Src)
+	draw.Draw(im.RGBA, bounds, src, src.Bounds().Min, draw.Src)
 }
 
 type Window struct {

--- a/win/dib_windows.go
+++ b/win/dib_windows.go
@@ -118,7 +118,7 @@ func (p *DIB) Opaque() bool {
 
 func (p *DIB) CopyRGBA(src *image.RGBA, r image.Rectangle) {
         // clip r against each image's bounds and move sp accordingly (see draw.clip())
-	sp := image.ZP
+	sp := src.Bounds().Min
 	orig := r.Min
 	r = r.Intersect(p.Bounds())
 	r = r.Intersect(src.Bounds().Add(orig.Sub(sp)))

--- a/xgb/xgb.go
+++ b/xgb/xgb.go
@@ -218,7 +218,7 @@ type Image struct {
 
 func (buffer Image) CopyRGBA(src *image.RGBA, r image.Rectangle) {
 	// clip r against each image's bounds and move sp accordingly (see draw.clip())
-	sp := image.ZP
+	sp := src.Bounds().Min
 	orig := r.Min
 	r = r.Intersect(buffer.Bounds())
 	r = r.Intersect(src.Bounds().Add(orig.Sub(sp)))


### PR DESCRIPTION
Arguably this is a bug with go's image package and its failure to allow efficient blitting implementations to/from non-builtin image types (BGRA in our case). Anyway, the current implementation of CopyRGBA is not useful when dealing with images whose top-left bounding point is not image.ZP.

The following code demonstrates the issue:
```
package main

import (
	"image"
	"image/color"
	"image/draw"
	"github.com/skelterjohn/go.wde"
	_ "github.com/skelterjohn/go.wde/init"
)

func main() {
	go func() {
		w, _ := wde.NewWindow(300, 300)
		w.Show()
		screen := w.Screen()
		draw.Draw(screen, screen.Bounds(), &image.Uniform{color.Black}, image.ZP, draw.Src)
		centre := image.NewRGBA(screen.Bounds().Inset(50))
		src := &image.Uniform{color.RGBA{0xff, 0x00, 0x00, 0xff}}
		draw.Draw(centre, centre.Bounds(), src, image.ZP, draw.Src)
		screen.CopyRGBA(centre, centre.Bounds())
		w.FlushImage()
	}()
	wde.Run()
}
```

ie. the screen's image has bounds (0,0)-(300,300). centre has bounds (50,50)-(250,250). But the part of the window that actually gets drawn red is (100,100)-(250,250) - there's an extra translation going on.

This PR causes the area (50,50)-(250,250) to be drawn red (tested on linux only). It shouldn't change the results for images that are anchored on image.ZP.