### PR TITLE
osx: add support for mousewheel, non-primary buttons and gestures

### DIFF
--- a/cocoa/EventWindow.m
+++ b/cocoa/EventWindow.m
@@ -130,6 +130,30 @@
     [self mouseDragged:theEvent];
 }
 
+static int sgn(CGFloat delta)
+{
+    if (delta < 0)
+        return -1;
+    if (delta > 0)
+        return 1;
+    return 0;
+}
+
+- (void)scrollWheel:(NSEvent *)theEvent
+{
+    GMDEvent e = [self mouseEvent:theEvent]; // fill in x/y coords
+    if ([theEvent hasPreciseScrollingDeltas]) {
+        e.kind = GMDScroll;
+        e.data[2] = (int)[theEvent scrollingDeltaX];
+        e.data[3] = (int)[theEvent scrollingDeltaY];
+    } else {
+        e.kind = GMDMouseWheel;
+        e.data[2] = sgn([theEvent scrollingDeltaX]);
+        e.data[3] = sgn([theEvent scrollingDeltaY]);
+    }
+    [self nq:e];
+}
+
 - (void)mouseMoved:(NSEvent *)theEvent
 {
     CGRect frameOrigin = [self frame];
@@ -154,6 +178,22 @@
 {
     GMDEvent e = [self mouseEvent:theEvent];
     e.kind = GMDMouseExited;
+    [self nq:e];
+}
+
+- (void)magnifyWithEvent:(NSEvent *)theEvent
+{
+    GMDEvent e = [self mouseEvent:theEvent]; // fill in x/y coords
+    e.kind = GMDMagnify;
+    e.data[2] = (int)([theEvent magnification] * 65536.0);
+    [self nq:e];
+}
+
+- (void)rotateWithEvent:(NSEvent *)theEvent
+{
+    GMDEvent e = [self mouseEvent:theEvent]; // fill in x/y coords
+    e.kind = GMDRotate;
+    e.data[2] = (int)([theEvent rotation] * 65536.0);
     [self nq:e];
 }
 

--- a/cocoa/EventWindow.m
+++ b/cocoa/EventWindow.m
@@ -100,6 +100,36 @@
     [self nq:e];
 }
 
+- (void)rightMouseDown:(NSEvent *)theEvent
+{
+    [self mouseDown:theEvent];
+}
+
+- (void)otherMouseDown:(NSEvent *)theEvent
+{
+    [self mouseDown:theEvent];
+}
+
+- (void)rightMouseUp:(NSEvent *)theEvent
+{
+    [self mouseUp:theEvent];
+}
+
+- (void)otherMouseUp:(NSEvent *)theEvent
+{
+    [self mouseUp:theEvent];
+}
+
+- (void)rightMouseDragged:(NSEvent *)theEvent
+{
+    [self mouseDragged:theEvent];
+}
+
+- (void)otherMouseDragged:(NSEvent *)theEvent
+{
+    [self mouseDragged:theEvent];
+}
+
 - (void)mouseMoved:(NSEvent *)theEvent
 {
     CGRect frameOrigin = [self frame];

--- a/cocoa/events_darwin.go
+++ b/cocoa/events_darwin.go
@@ -125,6 +125,38 @@ func (w *Window) EventChan() (events <-chan interface{}) {
 				}
 				lastXY = me.Where
 				ec <- me
+			case C.GMDMouseWheel:
+				var me wde.MouseEvent
+				me.Where.X = int(e.data[0])
+				me.Where.Y = int(e.data[1])
+				// TODO e.data[2] contains horizontal scroll info; what do?
+				if e.data[3] != 0 {
+					button := wde.WheelUpButton
+					if e.data[3] == -1 {
+						button = wde.WheelDownButton
+					}
+					ec <- wde.MouseDownEvent{me, button}
+					ec <- wde.MouseUpEvent{me, button}
+				}
+			case C.GMDMagnify:
+				var mge wde.MagnifyEvent
+				mge.Where.X = int(e.data[0])
+				mge.Where.Y = int(e.data[1])
+				mge.Magnification = 1 + float64(e.data[2]) / 65536
+				ec <- mge
+			case C.GMDRotate:
+				var rte wde.RotateEvent
+				rte.Where.X = int(e.data[0])
+				rte.Where.Y = int(e.data[1])
+				rte.Rotation = float64(e.data[2]) / 65536
+				ec <- rte
+			case C.GMDScroll:
+				var se wde.ScrollEvent
+				se.Where.X = int(e.data[0])
+				se.Where.Y = int(e.data[1])
+				se.Delta.X = int(e.data[2])
+				se.Delta.Y = int(e.data[3])
+				ec <- se
 			case C.GMDMainFocus:
 				// for some reason Cocoa resets the cursor to normal when the window
 				// becomes the "main" window, so we have to set it back to what we want

--- a/cocoa/events_darwin.go
+++ b/cocoa/events_darwin.go
@@ -31,6 +31,10 @@ func getButton(b int) (which wde.Button) {
 	switch b {
 	case 0:
 		which = wde.LeftButton
+	case 1:
+		which = wde.RightButton
+	case 2:
+		which = wde.MiddleButton
 	}
 	return
 }

--- a/cocoa/gmd.h
+++ b/cocoa/gmd.h
@@ -26,6 +26,10 @@ enum GMDEventCodes {
     GMDClose = 11,
     GMDKeyFocus = 12, // got keyboard focus
     GMDMainFocus = 13, // became "main" window
+    GMDMagnify = 14,
+    GMDRotate = 15,
+    GMDScroll = 16,
+    GMDMouseWheel = 17,
 };
 
 typedef void* GMDWindow;

--- a/events.go
+++ b/events.go
@@ -68,6 +68,27 @@ type MouseEnteredEvent MouseMovedEvent
 // MouseExitedEvent is for when the mouse exits a window.
 type MouseExitedEvent MouseMovedEvent
 
+// MagnifyEvent is used to represent a magnification gesture.
+type MagnifyEvent struct {
+	Event
+	Where image.Point
+	Magnification float64 // the multiplicative scale factor
+}
+
+// RotateEvent is used to represent a rotation gesture.
+type RotateEvent struct {
+	Event
+	Where image.Point
+	Rotation float64 // measured in degrees; positive == clockwise
+}
+
+// Scroll Event is used to represent a scrolling gesture.
+type ScrollEvent struct {
+	Event
+	Where image.Point
+	Delta image.Point
+}
+
 // KeyEvent is used for data common to all key events, and should not appear as an event received by the caller program.
 type KeyEvent struct {
 	Key string

--- a/wdetest/wdetest.go
+++ b/wdetest/wdetest.go
@@ -71,6 +71,12 @@ func wdetest() {
 					fmt.Println("mouse entered", e.Where.X, e.Where.Y)
 				case wde.MouseExitedEvent:
 					fmt.Println("mouse exited", e.Where.X, e.Where.Y)
+				case wde.MagnifyEvent:
+					fmt.Println("magnify", e.Where, e.Magnification)
+				case wde.RotateEvent:
+					fmt.Println("rotate", e.Where, e.Rotation)
+				case wde.ScrollEvent:
+					fmt.Println("scroll", e.Where, e.Delta)
 				case wde.KeyDownEvent:
 					// fmt.Println("KeyDownEvent", e.Glyph)
 				case wde.KeyUpEvent:


### PR DESCRIPTION
I got to spend some quality time with an actual OSX box yesterday, and added support for some mouse/gesture events which were previously ignored:

* mouse clicks/drags with the non-primary button
* mouse wheel events
* standard touch gestures (pinch/rotate/scroll)

This PR adds support for all three; I consider gestures essential for providing a quality ux on the platform. Notes:

* cocoa calls [NSResponder scrollWheel ]for both mouse scroll wheel events and scrolling gestures (two-finger swipes). I attempt to distinguish between the two via [NSEvent hasPreciseScrollingDeltas] which worked in my limited test scenarios.
* osx seems to have a reversed scroll-wheel convention compared to other platforms. ie. scrolling the mouse wheel down takes you upwards, toward the top of the document. I'm guessing this is to be consistent with scroll gestures (scrolling down with two fingers does intuitively shift the document down/viewpoint up). Currently I've plumbed a mouse-wheel-down scroll through as a WheelDownButton, but it may be worth considering reversing the mapping so that wde programs can transparently adapt to the native platform?
* the scrollWheel event also supports left and right scroll wheels, which currently get dropped on the floor. This may be obscure enough not to worry about (left/right scrolling gestures *are* supported).
* MagnifyEvent would perhaps be better named PinchEvent to avoid imprinting expected UI behaviours, but I think that ship has sailed